### PR TITLE
Fix compilation under Clang

### DIFF
--- a/vgm2opm.c
+++ b/vgm2opm.c
@@ -77,6 +77,7 @@ static void init_chip(enum vgm_chip_id chip_id, int clock, void *data_ptr) {
 			add_analyzer((struct chip_analyzer *)opm_analyzer_new(clock), chip_id);
 			break;
 		default:
+			break;
 	}
 }
 


### PR DESCRIPTION
```
vgm2opm.c:79:11: error: label at end of compound statement: expected statement
                default:
                        ^
                         ;
```

There's also an extra warning about some indentation it doesn't like, but that's just a warning so I didn't touch.
```
vgm/interpreter.c:72:79: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
                                case 0x61: if(it->wait) it->wait(buf[i+1] | buf[i+2] << 8, it->data_ptr); break;
                                                                                                          ^
vgm/interpreter.c:71:6: note: previous statement is here
                        } else switch(buf[i]) {
                          ^
```